### PR TITLE
Add Lockpaw to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1786,6 +1786,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 
 - [BridgeBlock](https://gitlab.com/andrew_vanderbilt/bridgeblock)
 - [Enpass](https://www.enpass.io)
+- [Lockpaw](https://getlockpaw.com)
 - [OneTimeCopy](https://github.com/adama11/OneTimeCopy)
 - [Security Growler](https://github.com/pirate/security-growler)
 - [swiftGuard](https://github.com/Lennolium/swiftGuard)


### PR DESCRIPTION
Adds [Lockpaw](https://getlockpaw.com) to the Security section.

Lockpaw is a free, open-source macOS menu bar screen guard. Lock/unlock your screen with a hotkey, with Touch ID as a fallback.

- Website: https://getlockpaw.com
- Source: https://github.com/sorkila/lockpaw