### PR TITLE
Add Lockpaw to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1786,6 +1786,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 
 - [BridgeBlock](https://gitlab.com/andrew_vanderbilt/bridgeblock)
 - [Enpass](https://www.enpass.io)
+- [Lockpaw](https://github.com/sorkila/lockpaw)
 - [OneTimeCopy](https://github.com/adama11/OneTimeCopy)
 - [Security Growler](https://github.com/pirate/security-growler)
 - [swiftGuard](https://github.com/Lennolium/swiftGuard)


### PR DESCRIPTION
## Summary

- Adds [Lockpaw](https://github.com/sorkila/lockpaw) to the Security section in alphabetical order
- Lockpaw locks the screen while letting background tasks keep running. Native macOS menu bar app (Swift/SwiftUI), open source, free.
- Website: https://getlockpaw.com