### PR TITLE
Add Lockpaw (resubmission of #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1786,6 +1786,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 
 - [BridgeBlock](https://gitlab.com/andrew_vanderbilt/bridgeblock)
 - [Enpass](https://www.enpass.io)
+- [Lockpaw](https://github.com/sorkila/lockpaw)
 - [OneTimeCopy](https://github.com/adama11/OneTimeCopy)
 - [Security Growler](https://github.com/pirate/security-growler)
 - [swiftGuard](https://github.com/Lennolium/swiftGuard)

--- a/README.md
+++ b/README.md
@@ -1786,7 +1786,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 
 - [BridgeBlock](https://gitlab.com/andrew_vanderbilt/bridgeblock)
 - [Enpass](https://www.enpass.io)
-- [Lockpaw](https://github.com/sorkila/lockpaw)
+- [Lockpaw](https://github.com/sorkila/lockpaw) by [Erik Nielsen](https://sorkila.com/) — Lock your Mac without putting it to sleep — Free, open source (MIT License)
 - [OneTimeCopy](https://github.com/adama11/OneTimeCopy)
 - [Security Growler](https://github.com/pirate/security-growler)
 - [swiftGuard](https://github.com/Lennolium/swiftGuard)


### PR DESCRIPTION
This resubmits #11, which was auto-closed when I accidentally deleted the source fork during a cleanup — it wasn't rejected. Apologies for the noise!

Lockpaw is a menu bar screen guard for macOS: cover/lock your screen with a hotkey without putting it to sleep, so builds and AI agents keep running while input is blocked, and the locked screen glows when your agent needs you. Touch ID unlock. Free, MIT-licensed, native Swift, no telemetry.

Links: https://getlockpaw.com · https://github.com/sorkila/lockpaw