### PR TITLE
Add TypeCue to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 - [Slack Status Bar](https://github.com/ericwb/slack-status-bar/)
 - [Slack Status Icon](https://github.com/strayge/slack_status_icon)
 - [Slapp](https://github.com/shersch/slapp)
+- [TypeCue](https://typecue.app) by [Alex Polonsky](https://alexpolonsky.com) — Types a prepared script into any app, one hotkey press per line, as real keystrokes at a human pace — Free, open source
 - [Workday](https://github.com/becurrie/workday)
 
 ### Activity Tracking


### PR DESCRIPTION
Adds TypeCue, a free and open-source macOS menu bar app that types a prepared script into any app - one hotkey press per line, as real keystrokes at a human pace, with inline pause and speed markers. Built for demo recordings and live presentations.

Site: https://typecue.app
Source: https://github.com/alexpolonsky/TypeCue