### PR TITLE
Add McAwake to Caffeinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1963,6 +1963,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 - [Jiggler](http://www.sticksoftware.com/software/Jiggler.html)
 - [KeepingYouAwake](https://keepingyouawake.app)
 - [NeSleep](https://vishalroygeek.gumroad.com/l/nesleep)
+- [NightOwl](https://github.com/taufiqxr/NightOwl) by [taufiqxr](https://github.com/taufiqxr) — Keep your Mac awake even with the lid closed, no external display needed — Free, open source
 - [NoSleep](https://github.com/integralpro/nosleep)
 - [Owly](https://apps.apple.com/us/app/owly-prevent-display-sleep/id882812218?mt=12)
 - [RocketFuel](https://github.com/pkrll/RocketFuel)

--- a/README.md
+++ b/README.md
@@ -1962,8 +1962,8 @@ If you find that an app is missing, that any of the links are broken, or that th
 - [InsomniaX](https://insomniax.en.softonic.com/mac)
 - [Jiggler](http://www.sticksoftware.com/software/Jiggler.html)
 - [KeepingYouAwake](https://keepingyouawake.app)
+- [McAwake](https://github.com/taufiqxr/McAwake) by [taufiqxr](https://github.com/taufiqxr) — Keep your Mac awake even with the lid closed, no external display needed — Free, open source
 - [NeSleep](https://vishalroygeek.gumroad.com/l/nesleep)
-- [NightOwl](https://github.com/taufiqxr/NightOwl) by [taufiqxr](https://github.com/taufiqxr) — Keep your Mac awake even with the lid closed, no external display needed — Free, open source
 - [NoSleep](https://github.com/integralpro/nosleep)
 - [Owly](https://apps.apple.com/us/app/owly-prevent-display-sleep/id882812218?mt=12)
 - [RocketFuel](https://github.com/pkrll/RocketFuel)


### PR DESCRIPTION
Adds **[McAwake](https://github.com/taufiqxr/McAwake)** to the **Caffeinators** subsection, in alphabetical order (between `KeepingYouAwake` and `NeSleep`).

McAwake is a free, MIT-licensed, open-source macOS 13+ menu bar app that keeps a Mac awake **even with the lid closed and no external display** — it drives `pmset disablesleep`, which handles the clamshell case that idle-sleep assertion tools can't. It also has a Smart Auto mode (awake on AC, normal sleep on battery), a low-battery guard that restores sleep below 15% battery, live local server/tunnel monitoring with down/up notifications, and a Claude Code session switcher.

Notes:

- I'm the developer.
- Ad-hoc signed, not notarized — documented in the README along with install instructions.
- **This PR was opened when the app was named NightOwl**, which collided with the unrelated [NightOwl](https://nightowl.kramser.xyz) already listed under Settings. The app has since been renamed to McAwake (v2.0.0), so that collision is gone entirely. The entry and links are updated and re-sorted; the branch is still called `add-nightowl` because renaming it would close this PR.
