### PR TITLE
Add Actvt to AI Agents & AI Harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1268,6 +1268,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 
 #### AI Agents & AI Harnesses
 
+- [Actvt](https://actvt.io) by [Oye Collective](https://oyecollective.com) — Monitors your Mac and the AI coding agents on it, with searchable Claude Code and Codex session history, cost and token analytics, and an embedded MCP server — Free tier, then $9.99 one-time or $7.99/mo billed annually
 - [MenubarCC](https://github.com/ksterx/MenubarCC) by [Kosuke Ishikawa](https://ksterx.me/) — Menu bar crab that shows your Claude Code sessions at a glance: walking while Claude works, bouncing when it needs you — Free, open source
 - [Notch So Good](https://github.com/deepshal99/notch-so-good) by [Deepak Maurya](https://github.com/deepshal99) — A pixel-art crab lives in your MacBook's notch and monitors Claude Code sessions with 13 animations, smart notifications, and multi-session support — Free, open source
 


### PR DESCRIPTION
Adds Actvt, a native macOS menu bar app that monitors the Mac and the AI coding agents running on it. Live CPU, GPU, memory and network, plus every Claude Code and Codex
session indexed locally and searchable, with cost and token numbers.

Filed under AI Agents & AI Harnesses to sit with MenubarCC and Notch So Good, since the agent session monitoring is the closest match. If you would rather have it under System
Status → Local System Status, that fits too and I am happy either way.

macOS 15.5 or later, Apple Silicon only. Direct download, not on the Mac App Store.