### PR TITLE
Add Waindow to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2284,6 +2284,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 - [Spectacle](https://www.spectacleapp.com)
 - [Swish](https://highlyopinionated.co/swish/)
 - [Tiles](https://www.sempliva.com/tiles/) by [Sempliva](https://www.sempliva.com)
+- [Waindow](https://waindow.app) by [indiveloper](https://github.com/indiveloper) — Window layouts, linked resizing, window-specific notes, long-page capture, Blackout Mode, and Keep Awake — Free
 - [Warp](https://mkchoi212.gumroad.com/l/qjkjf)
 - [Window Collage](https://www.minicreo.com/window-collage/)
 - [WindowKeys](https://www.apptorium.com/windowkeys)


### PR DESCRIPTION
## What changed

- Added Waindow to the **Window Management** section in alphabetical order.
- Linked to the official product homepage and identified its core menu bar utilities.

## Why

Waindow is a free macOS menu bar app for window layouts, linked resizing, window-specific notes, long-page capture, Blackout Mode, and Keep Awake. It is not currently listed in the megalist.

## Validation

- Confirmed there is no existing Waindow entry, issue, or pull request.
- Confirmed the official homepage resolves successfully.
- Ran `git diff --check`.
