### PR TITLE
Add AI Dictation to Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -2132,6 +2132,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 
 #### Speech
 
+- [AI Dictation](https://aidictation.com) by [Writingmate](https://github.com/writingmate) — Voice-to-text from the menu bar with offline recognition on supported devices and optional cloud transcription and cleanup — Free tier, MIT-licensed native client source
 - [AudioBuddy](https://zeitalabs.gumroad.com/l/audiobuddy)
 - [QuickSpeak](https://apps.apple.com/us/app/quickspeak-text-to-speech/id1669506658?mt=12)
 


### PR DESCRIPTION
## What changed

- Added AI Dictation to `Utilities > Text > Speech`.
- Linked the product website and identified its free tier and MIT-licensed native client source.

## Why

AI Dictation is a working macOS menu-bar voice-to-text app. It fits the list's stated goal of recording all available macOS menu-bar apps and the existing Speech subsection.

## Validation

- Confirmed the current macOS source creates an `NSStatusItem` and starts in menu-bar-only mode.
- Confirmed the website and source repository return HTTP 200.
- Confirmed there is no existing AI Dictation entry or open submission.
- Ran `git diff --check` and `npx --yes markdownlint-cli2 README.md` with no issues.

## Disclosure

I am affiliated with AI Dictation. This focused entry was prepared with AI assistance and manually checked against the current app source, website, repository, and list format.
