### PR TITLE
Add Holeberry to Networking / IT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1760,6 +1760,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 
 ### Networking / IT
 
+- [Holeberry](https://github.com/pedrovieira/Holeberry) by [Pedro Vieira](https://pedrovieira.me/) — Monitor and control your Pi-hole instances from the menu bar — Free, open source
 - [IPInfo](https://github.com/bentettmar/ipinfo)
 - [IPMenu](https://github.com/disrvptor/IPMenu)
 - [Network Interface Menubar](https://github.com/g-k/network-interface-menubar)


### PR DESCRIPTION
## Description

Adds [Holeberry](https://github.com/pedrovieira/Holeberry) to the **Utilities → Networking / IT** section.

Holeberry is a native, modern macOS menu bar app (Swift 6) that puts your Pi-hole® right in the menu bar: check blocking status and query stats, disable blocking for a set time or indefinitely, unblock the domain in your current browser tab, and allowlist or unblock recently-blocked domains — no browser tab required.

- **Price**: Free
- **License**: MIT, open source
- **Platform**: macOS 14+ (Sonoma or later); supports Pi-hole v5 & v6, multiple instances, global keyboard shortcuts
- **Links**: [GitHub](https://github.com/pedrovieira/Holeberry) · [Website](https://holeberryapp.com) · [Releases](https://github.com/pedrovieira/Holeberry/releases)
- **Entry added alphabetically** at the top of the Networking / IT section (before IPInfo)