### PR TITLE
Add AI Subscription Usage to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,7 +1237,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 ### AI
 
 - [AI Chat](https://www.chatbar.top)
-- [AI Subscription Usage](https://github.com/billwonghk/ai-subscription-usage) — Compares your ChatGPT/Claude/Gemini/Grok subscription cost against real API-equivalent value, from local usage logs — Free, open source
+- [AI Subscription Usage](https://github.com/billwonghk/ai-subscription-usage) by [billwonghk](https://github.com/billwonghk) — Compares ChatGPT/Claude/Gemini/Grok subscription cost against API-equivalent value, based on local usage logs — Free, open source (PolyForm Noncommercial License)
 - [Apple AI](https://bunnysayzz.github.io/AppleAI/) by [Md Azharuddin](https://imazhar.vercel.app) — A unified interface for multiple AI assistants — Free, open source
 - [ChatGPT](https://github.com/vincelwt/chatgpt-mac)
 - [ChatGPT Client](https://github.com/pseudocoder-in/ChatGPT)

--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 ### AI
 
 - [AI Chat](https://www.chatbar.top)
+- [AI Subscription Usage](https://github.com/billwonghk/ai-subscription-usage) — Compares your ChatGPT/Claude/Gemini/Grok subscription cost against real API-equivalent value, from local usage logs — Free, open source
 - [Apple AI](https://bunnysayzz.github.io/AppleAI/) by [Md Azharuddin](https://imazhar.vercel.app) — A unified interface for multiple AI assistants — Free, open source
 - [ChatGPT](https://github.com/vincelwt/chatgpt-mac)
 - [ChatGPT Client](https://github.com/pseudocoder-in/ChatGPT)


### PR DESCRIPTION
Adds [AI Subscription Usage](https://github.com/billwonghk/ai-subscription-usage) to the AI section, alongside the other ChatGPT-related menu bar apps already listed.

Free, open-source menu bar app for macOS (and Windows tray). Reads local usage logs for ChatGPT, Claude, Gemini, and Grok and compares 30 days of API-equivalent value against what you actually pay for each subscription — no API key, no account login, everything stays on-device.