### PR TITLE
Add Planim Time to Time/Habit Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,7 @@ If you find that an app is missing, that any of the links are broken, or that th
 - [Me Focused](https://apps.apple.com/us/app/me-focused/id1546276197?mt=12)
 - [Mini Time Tracker](https://apps.apple.com/us/app/mini-time-tracker/id1633674659?mt=12)
 - [Owl Timekeeper](https://github.com/kawmra/Owl-Timekeeper)
+- [Planim Time](https://time.planim.app/jira) by [Planim](https://planim.app) — Time tracker for Jira with a one-click timer, two-way worklog sync, and offline-first local storage — Free tier with unlimited tracking and Jira sync, Pro $10/month adds auto-push, calendar and reports
 - [Prepend](https://apps.apple.com/us/app/prepend/id1584128314?mt=12)
 - [Recess](https://apps.apple.com/us/app/recess/id621451282?mt=12)
 - [RestMinder](https://apps.apple.com/us/app/restminder/id1575673623?mt=12)


### PR DESCRIPTION
Adds Planim Time to Time/Habit Tracking, in alphabetical order between Owl Timekeeper and Prepend.

Menu bar time tracker for Jira: one-click timer per issue, worklogs pushed to Jira, two-way sync, calendar view, works offline. Free tier has no tracking limits; Pro ($10/month, or $150 lifetime) adds automatic push, calendar view, idle detection and reports. I'm the developer.
